### PR TITLE
added results poll id

### DIFF
--- a/client/views/pages/Results.jsx
+++ b/client/views/pages/Results.jsx
@@ -2,8 +2,8 @@ Results = React.createClass({
   render() {
     return (
       <div>
-        <h1>Poll Result</h1>
-        <p>The poll ID is {this.props.pollId}</p>
+        <h1>Poll Results</h1>
+        <p>The results poll ID is {this.props.resultId}</p>
       </div>
     );
   }

--- a/models/polls.js
+++ b/models/polls.js
@@ -17,6 +17,14 @@ var PollSchema = new SimpleSchema({
     unique: true,
     denyUpdate: true
   },
+  resulturl: {
+    type: String,
+    regEx: /^[a-zA-Z0-9]+$/,
+    max: 8,
+    index: true,
+    unique: true,
+    denyUpdate: true
+  },
   createdOn: {
     type: Date,
     defaultValue: new Date(),

--- a/server/lib/methods.js
+++ b/server/lib/methods.js
@@ -1,5 +1,8 @@
 Meteor.methods({
   createPoll: function(pollData) {
-    return Polls.insert(pollData);
+    var resulturl = Random.id(8);
+    Polls.insert(_.extend(pollData, { resulturl }));
+
+    return resulturl;
   }
 });


### PR DESCRIPTION
A poll ID and the ID for its results page should be different. This is to have an option of not allowing participants to see the results after they vote. If these two IDs were the same, participants can easily go to the results page because they know the poll ID.

We will use `/poll/xxxxx` for a poll, and `/results/yyyyy` for its results page.